### PR TITLE
Update config to remove Propel feed handler

### DIFF
--- a/config/Common.php
+++ b/config/Common.php
@@ -18,7 +18,6 @@ class Common extends ContainerConfig
          * @var \Rssr\Feed\Factory
          */
         $factory = $di->get('rssr/feeds:factory');
-        $factory->addHandler('Rssr\Feed\Propel');
         $factory->addHandler('Rssr\Feed\Atom');
         $factory->addHandler('Rssr\Feed\Rss');
 


### PR DESCRIPTION
This should be added by an app that combines propel and rssr feeds.
